### PR TITLE
feat: allow for withdraw to a different player's inventory

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -4,7 +4,7 @@
     "name": "blurpesec",
     "email": "hahn.michael.f@gmail.com"
   },
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "license": "MIT",
   "scripts": {

--- a/packages/contracts/src/codegen/world/IStorageSystem.sol
+++ b/packages/contracts/src/codegen/world/IStorageSystem.sol
@@ -20,10 +20,16 @@ interface IStorageSystem {
     InventoryItemParams[] memory transferItems
   ) external;
 
+  function sm_v0_2_0__transferToPlayer(
+    uint256 smartObjectId,
+    bytes32 bucketId,
+    address recipient,
+    InventoryItemParams[] memory transferItems
+  ) external;
+
   function sm_v0_2_0__withdraw(
     uint256 smartObjectId,
     bytes32 bucketId,
-    bool useOwnerInventory,
     InventoryItemParams[] memory transferItems
   ) external;
 

--- a/packages/contracts/test/StorageManager/StorageManagerPrimaryTest.t.sol
+++ b/packages/contracts/test/StorageManager/StorageManagerPrimaryTest.t.sol
@@ -152,10 +152,11 @@ contract StorageManagerPrimaryTest is SetupTestWithBucketsTest {
       afterDepositBucketBalance,
       "Expected bucket balance to be the same as the total deposit amount before withdraw"
     );
+    address ownerOfSSU = OwnershipByObject.getAccount(ssuId);
     // Test unauthorized Deposit items into bucket
     vm.startPrank(unauthorizedPlayer);
     vm.expectRevert(UnauthorizedWithdraw.selector);
-    world.sm_v0_2_0__withdraw(ssuId, bucketId, true, withdrawTransferItems);
+    world.sm_v0_2_0__transferToPlayer(ssuId, bucketId, ownerOfSSU, withdrawTransferItems);
     vm.stopPrank();
 
     // Test authorized account, but unauthorized sender - Deposit items into bucket
@@ -179,7 +180,7 @@ contract StorageManagerPrimaryTest is SetupTestWithBucketsTest {
     // Authorized Deposit items into bucket
     uint64 primaryBalanceBeforeWithdraw = uint64(InventoryItem.getQuantity(ssuId, itemId));
     vm.startPrank(player);
-    world.sm_v0_2_0__withdraw(ssuId, bucketId, true, withdrawTransferItems);
+    world.sm_v0_2_0__transferToPlayer(ssuId, bucketId, ownerOfSSU, withdrawTransferItems);
     vm.stopPrank();
     // Verify the deposit was successful
     uint64 primaryBalanceAfterWithdraw = uint64(InventoryItem.getQuantity(ssuId, itemId));
@@ -235,10 +236,12 @@ contract StorageManagerPrimaryTest is SetupTestWithBucketsTest {
       afterDepositBucketBalance,
       "Expected bucket balance to be the same as the total deposit amount before withdraw"
     );
+    address ownerOfSSU = OwnershipByObject.getAccount(ssuId);
+
     // Test unauthorized Deposit items into bucket
     vm.startPrank(unauthorizedPlayer);
     vm.expectRevert(UnauthorizedWithdraw.selector);
-    world.sm_v0_2_0__withdraw(ssuId, bucketId, true, withdrawTransferItems);
+    world.sm_v0_2_0__transferToPlayer(ssuId, bucketId, ownerOfSSU, withdrawTransferItems);
     vm.stopPrank();
 
     // Test authorized account, but unauthorized sender - Deposit items into bucket
@@ -262,7 +265,7 @@ contract StorageManagerPrimaryTest is SetupTestWithBucketsTest {
     // Authorized Deposit items into bucket
     uint64 primaryBalanceBeforeWithdraw = uint64(InventoryItem.getQuantity(ssuId, itemId));
     vm.startPrank(player);
-    world.sm_v0_2_0__withdraw(ssuId, bucketId, true, withdrawTransferItems);
+    world.sm_v0_2_0__transferToPlayer(ssuId, bucketId, ownerOfSSU, withdrawTransferItems);
     vm.stopPrank();
     // Verify the deposit was successful
     uint64 primaryBalanceAfterWithdraw = uint64(InventoryItem.getQuantity(ssuId, itemId));

--- a/packages/contracts/test/StorageManager/StoreAuthDelegatedAccessTest.t.sol
+++ b/packages/contracts/test/StorageManager/StoreAuthDelegatedAccessTest.t.sol
@@ -64,7 +64,9 @@ contract StoreAuthDelegatedAccessTest is SetupTestWithBucketsTest {
     assertFalse(canTransfer, "Expected delegated canTransferBucket to return false");
   }
 
-  function testRegisterDelegatedAccessSystemAndAuthorize() public {
+  function testProxyTransferSystem() public {
+    
+
     
   }
 }


### PR DESCRIPTION
This pull request introduces a significant refactor and enhancement of the storage system's withdrawal logic, primarily by splitting the previous `withdraw` function into two distinct operations: `withdraw` (now simplified) and a new `transferToPlayer` function. The changes clarify the semantics of withdrawing items from storage buckets, improve authorization checks, and add more granular control over item transfers. Test coverage is updated and expanded to reflect and verify the new logic.

**Core Storage Logic Refactor:**

* Introduced a new `transferToPlayer` function in `StorageSystem`, enabling direct transfers from a bucket to a specified player’s ephemeral inventory, with improved authorization and clearer separation of responsibilities. The original `withdraw` function is now a wrapper that calls `transferToPlayer` for the message initiator. [[1]](diffhunk://#diff-2f1f17d353936b4e3e16ca4e2613b569463e56c247cc63c6dc81cf020bb8c981L79-L88) [[2]](diffhunk://#diff-2f1f17d353936b4e3e16ca4e2613b569463e56c247cc63c6dc81cf020bb8c981L102-R128)
* Updated `StorageSystemLib` to include new internal and root call wrappers for `transferToPlayer`, and refactored the `withdraw` wrappers to remove the `useOwnerInventory` parameter, aligning with the new function signatures. [[1]](diffhunk://#diff-a0487d7221b7e2591f5f31d1497dadd4fe8c9a60ed450194d88bc316e57b8b8fL55-R72) [[2]](diffhunk://#diff-a0487d7221b7e2591f5f31d1497dadd4fe8c9a60ed450194d88bc316e57b8b8fR125-R155) [[3]](diffhunk://#diff-a0487d7221b7e2591f5f31d1497dadd4fe8c9a60ed450194d88bc316e57b8b8fR202-R224)
* Added and updated corresponding interfaces for the new and modified functions in the codegen and world interface files. [[1]](diffhunk://#diff-a0487d7221b7e2591f5f31d1497dadd4fe8c9a60ed450194d88bc316e57b8b8fL254-R306) [[2]](diffhunk://#diff-ead9563370f5b5963970f553deaadf3f5a8eb04220f72d0da3be356b63c468d1R23-L26)

**Test Suite Updates and Additions:**

* Refactored all usages of the old `withdraw` function in tests to use either the new `withdraw` or `transferToPlayer` as appropriate, including updating parameters and expected behaviors. [[1]](diffhunk://#diff-595589c3f1265c7151c3fe33095dc0b82fdfd28ad06dd2723290fceb032f0817L188-R188) [[2]](diffhunk://#diff-595589c3f1265c7151c3fe33095dc0b82fdfd28ad06dd2723290fceb032f0817L201-R201) [[3]](diffhunk://#diff-595589c3f1265c7151c3fe33095dc0b82fdfd28ad06dd2723290fceb032f0817L211-R211) [[4]](diffhunk://#diff-595589c3f1265c7151c3fe33095dc0b82fdfd28ad06dd2723290fceb032f0817L273-R273) [[5]](diffhunk://#diff-595589c3f1265c7151c3fe33095dc0b82fdfd28ad06dd2723290fceb032f0817L286-R286) [[6]](diffhunk://#diff-093f66c3ad1cb3118814e4b690664d1784134338574008f515a867c7d02f2cf0R155-R159) [[7]](diffhunk://#diff-093f66c3ad1cb3118814e4b690664d1784134338574008f515a867c7d02f2cf0L182-R183) [[8]](diffhunk://#diff-093f66c3ad1cb3118814e4b690664d1784134338574008f515a867c7d02f2cf0R239-R244) [[9]](diffhunk://#diff-093f66c3ad1cb3118814e4b690664d1784134338574008f515a867c7d02f2cf0L265-R268)
* Added a comprehensive new test `testWithdrawFullFromBucketToPlayer` to verify the full withdrawal and transfer process, including authorization checks, balance updates, and cleanup of inventory records.

**Other Changes:**

* Bumped the package version from `0.2.3` to `0.2.4` to reflect the breaking and additive changes.
* Renamed and stubbed out a test function in `StoreAuthDelegatedAccessTest` for future proxy transfer system tests.